### PR TITLE
fix(secure-api): Do not clean up secure api script

### DIFF
--- a/lib/src/script.ts
+++ b/lib/src/script.ts
@@ -34,7 +34,7 @@ export function fetchScript({
 
     const onComplete = (event, callback) => {
       try {
-        if (cleanup) {
+        if (!secureApi && cleanup) {
           element.removeChild(script);
         }
         callback(event);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hcaptcha/loader",
   "description": "This is a JavaScript library to easily configure the loading of the hCaptcha JS client SDK with built-in error handling.",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "author": "hCaptcha team and contributors",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
By removing the script tag for `secure-api.js` we prevent it loading the reset of the assets it requires to initialize.