### PR TITLE
feat(retry): Add delay and configuration parameters to retry

### DIFF
--- a/lib/__test__/loader.test.ts
+++ b/lib/__test__/loader.test.ts
@@ -81,7 +81,7 @@ describe('hCaptchaLoader', () => {
       mockFetchScript.mockRejectedValueOnce(SCRIPT_ERROR);
       mockFetchScript.mockResolvedValueOnce(SCRIPT_COMPLETE);
 
-      const promise = hCaptchaLoader({ sentry: false });
+      const promise = hCaptchaLoader({ sentry: false, retryDelay: 0 });
 
       await waitFor(() => {
         expect(mockFetchScript).toHaveBeenCalledTimes(2);
@@ -97,7 +97,7 @@ describe('hCaptchaLoader', () => {
       mockFetchScript.mockRejectedValueOnce(SCRIPT_ERROR);
       mockFetchScript.mockResolvedValueOnce(SCRIPT_COMPLETE);
 
-      const promise = hCaptchaLoader({ sentry: false });
+      const promise = hCaptchaLoader({ sentry: false, retryDelay: 0 });
 
       await waitFor(() => {
         expect(mockFetchScript).toHaveBeenCalledTimes(3);
@@ -112,7 +112,7 @@ describe('hCaptchaLoader', () => {
       mockFetchScript.mockRejectedValue('test error');
 
       try {
-        await hCaptchaLoader({ sentry: false, cleanup: true });
+        await hCaptchaLoader({ sentry: false, cleanup: true, retryDelay: 0 });
       } catch (error) {
         expect(mockFetchScript).toBeCalledTimes(3);
         expect(error.message).toBe(SCRIPT_ERROR);
@@ -131,7 +131,7 @@ describe('hCaptchaLoader', () => {
       mockFetchScript.mockRejectedValue(SCRIPT_ERROR);
 
       try {
-        await hCaptchaLoader({ sentry: false });
+        await hCaptchaLoader({ sentry: false, retryDelay: 0 });
       } catch(error) {
         expect(error.message).toEqual(SCRIPT_ERROR);
       }

--- a/lib/__test__/loader.test.ts
+++ b/lib/__test__/loader.test.ts
@@ -118,6 +118,36 @@ describe('hCaptchaLoader', () => {
         expect(error.message).toBe(SCRIPT_ERROR);
       }
     });
+
+    it('should wait retryDelay milliseconds between retry attempts', async () => {
+      mockFetchScript.mockRejectedValue('test error');
+
+      const retryDelay = 100;
+      const startTime = Date.now();
+
+      try {
+        await hCaptchaLoader({ sentry: false, retryDelay });
+      } catch (error) {
+        const elapsed = Date.now() - startTime;
+
+        // With 2 retries and 100ms delay each, then it should take at least 200ms
+        expect(elapsed).toBeGreaterThanOrEqual(200);
+        expect(mockFetchScript).toBeCalledTimes(3);
+      }
+    });
+
+    it('should respect custom maxRetries value', async () => {
+      mockFetchScript.mockRejectedValue('test error');
+
+      try {
+        await hCaptchaLoader({ sentry: false, maxRetries: 5, retryDelay: 0 });
+      } catch (error) {
+
+        // 1 initial + 5 retries = 6 total calls
+        expect(mockFetchScript).toBeCalledTimes(6);
+        expect(error.message).toBe(SCRIPT_ERROR);
+      }
+    });
   });
 
   describe('script error', () => {

--- a/lib/__test__/loader.test.ts
+++ b/lib/__test__/loader.test.ts
@@ -119,34 +119,33 @@ describe('hCaptchaLoader', () => {
       }
     });
 
-    it('should wait retryDelay milliseconds between retry attempts', async () => {
+    it('should wait retryDelay milliseconds between retry attempts', (done) => {
       mockFetchScript.mockRejectedValue('test error');
 
       const retryDelay = 100;
       const startTime = Date.now();
 
-      try {
-        await hCaptchaLoader({ sentry: false, retryDelay });
-      } catch (error) {
+      hCaptchaLoader({ sentry: false, retryDelay }).catch(() => {
         const elapsed = Date.now() - startTime;
 
         // With 2 retries and 100ms delay each, then it should take at least 200ms
         expect(elapsed).toBeGreaterThanOrEqual(200);
         expect(mockFetchScript).toBeCalledTimes(3);
-      }
+        
+        done();
+      });
     });
 
-    it('should respect custom maxRetries value', async () => {
+    it('should respect custom maxRetries value', (done) => {
       mockFetchScript.mockRejectedValue('test error');
 
-      try {
-        await hCaptchaLoader({ sentry: false, maxRetries: 5, retryDelay: 0 });
-      } catch (error) {
-
+      hCaptchaLoader({ sentry: false, maxRetries: 5, retryDelay: 0 }).catch((error: Error) => {
         // 1 initial + 5 retries = 6 total calls
         expect(mockFetchScript).toBeCalledTimes(6);
         expect(error.message).toBe(SCRIPT_ERROR);
-      }
+
+        done();
+      });
     });
   });
 

--- a/lib/src/constants.ts
+++ b/lib/src/constants.ts
@@ -6,6 +6,7 @@ export const SCRIPT_COMPLETE = 'script-loaded';
 export const SENTRY_TAG = '@hCaptcha/loader';
 
 export const MAX_RETRIES = 2;
+export const RETRY_DELAY = 1000;
 
 export enum SentryContext {
   ANDROID = 'Android',

--- a/lib/src/loader.ts
+++ b/lib/src/loader.ts
@@ -12,7 +12,7 @@ export const hCaptchaScripts = [];
 let lastLoadFailed = false;
 
 export function resetLoader(scriptLocation?: HTMLElement) {
-  hCaptchaScripts.length = 0; // Clears promises
+  hCaptchaScripts.splice(0); // Clears promises
 
   const element = getMountElement(scriptLocation);
   const frame: any = getFrame(element);

--- a/lib/src/loader.ts
+++ b/lib/src/loader.ts
@@ -1,4 +1,4 @@
-import { generateQuery, getFrame, getMountElement } from './utils';
+import { delay, generateQuery, getFrame, getMountElement } from './utils';
 import { HCAPTCHA_LOAD_FN_NAME, MAX_RETRIES, RETRY_DELAY, SCRIPT_ERROR, SCRIPT_ID, SENTRY_TAG } from './constants';
 import { initSentry } from './sentry';
 import { fetchScript } from './script';
@@ -121,10 +121,6 @@ export function hCaptchaApi(params: ILoaderParams = { cleanup: false }, sentry: 
     sentry.captureException(error);
     return Promise.reject(new Error(SCRIPT_ERROR));
   }
-}
-
-function delay(ms: number): Promise<void> {
-  return new Promise(resolve => setTimeout(resolve, ms));
 }
 
 export async function loadScript(

--- a/lib/src/script.ts
+++ b/lib/src/script.ts
@@ -50,7 +50,6 @@ onError?: (message) => void
       if (onError) {
         onError(script.src);
       }
-      script?.remove();
       onComplete(event, reject);
     };
 

--- a/lib/src/script.ts
+++ b/lib/src/script.ts
@@ -50,6 +50,7 @@ onError?: (message) => void
       if (onError) {
         onError(script.src);
       }
+      script?.remove();
       onComplete(event, reject);
     };
 

--- a/lib/src/types.ts
+++ b/lib/src/types.ts
@@ -23,6 +23,8 @@ export interface ILoaderParams extends IScriptParams {
     hl?: string;
     cleanup?: boolean;
     uj?: boolean;
+    maxRetries?: number;
+    retryDelay?: number;
 }
 
 export interface SentryHub {

--- a/lib/src/utils.ts
+++ b/lib/src/utils.ts
@@ -72,6 +72,10 @@ function getBrowser(): BrowserContext {
   return { name, version };
 }
 
+export function delay(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
 function getDevice(): DeviceContext {
   const userAgent = navigator.userAgent;
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hcaptcha/loader",
   "description": "This is a JavaScript library to easily configure the loading of the hCaptcha JS client SDK with built-in error handling.",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "author": "hCaptcha team and contributors",
   "license": "MIT",
   "keywords": [


### PR DESCRIPTION
Adds a delay to the retry mechanism in order to deal with latent network issues, allowing the network to potentially recover in-between retries.

This pull request also adds the ability for the implementer to configure the delay time and the amount of retries.