### PR TITLE
fix: support legacy inline resolution

### DIFF
--- a/inline.js
+++ b/inline.js
@@ -1,0 +1,1 @@
+export { default } from './dist/inline.js';

--- a/lib/esbuild.config.js
+++ b/lib/esbuild.config.js
@@ -103,15 +103,25 @@ if (WATCH) {
     ]
   });
 
-  // Build the modern browser bundle as importable string
-  await build({
+  // Build the modern browser bundle as importable strings
+  const inlineConfig = {
     entryPoints: [resolve(DIST, 'browser.js')],
     loader: {
       '.js': 'text',
     },
-    format: 'esm',
     minify: true,
+  };
+
+  await build({
+    ...inlineConfig,
+    format: 'esm',
     outfile: resolve(DIST, 'inline.js'),
+  });
+
+  await build({
+    ...inlineConfig,
+    format: 'cjs',
+    outfile: resolve(DIST, 'inline.cjs'),
   });
 
   // Transform to ES5

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@hcaptcha/loader",
   "description": "This is a JavaScript library to easily configure the loading of the hCaptcha JS client SDK with built-in error handling.",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "author": "hCaptcha team and contributors",
   "license": "MIT",
   "keywords": [
@@ -23,11 +23,14 @@
     },
     "./inline": {
       "types": "./dist/types/src/inline.d.ts",
-      "import": "./dist/inline.js"
+      "import": "./dist/inline.js",
+      "require": "./dist/inline.cjs",
+      "default": "./dist/inline.js"
     }
   },
   "files": [
     "README.md",
+    "inline.js",
     "dist",
     "!**/*.tsbuildinfo"
   ],


### PR DESCRIPTION
## What

- Add a root inline entrypoint for legacy package resolution.
- Export the inline loader for both ESM and CommonJS consumers.
- Bump the package to 2.4.1.

## Why

Bundlers without package exports support cannot resolve `@hcaptcha/loader/inline` from its current `dist`-only location.

## Testing

- Lint and typecheck
- 34 unit tests
- ESM and CommonJS package imports
- React Native 0.78 Metro bundle using the packaged loader through the RN SDK